### PR TITLE
Add additional keywords

### DIFF
--- a/flatpak/data/uk.co.mrbenshef.Boop-GTK.desktop
+++ b/flatpak/data/uk.co.mrbenshef.Boop-GTK.desktop
@@ -5,6 +5,6 @@ Type=Application
 Exec=boop-gtk
 Terminal=false
 Categories=Utility;GTK;
-Keywords=GTK;Tools;
+Keywords=GTK;Tools;format;lint;
 Icon=uk.co.mrbenshef.Boop-GTK
 StartupNotify=true


### PR DESCRIPTION
This helps with search tools on the Linux desktop. GNOME, KDE and others use keywords for generic lookups when users search for a certain application.

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

