### PR TITLE
docs: fix typos

### DIFF
--- a/data/fyi.zoey.Boop-GTK.metainfo.xml
+++ b/data/fyi.zoey.Boop-GTK.metainfo.xml
@@ -6,7 +6,7 @@
   <name>Boop-GTK</name>
   <summary>Port of IvanMathy's Boop to GTK, a scriptable scratchpad for developers.</summary>
   <description>
-    <p>Paste text, transform it (with user extendible javascipt), move on. Stop pasting sensitive infomation into sketchy sites to format JSON, compute a hash, etc.</p>
+    <p>Paste text, transform it (with user extendible javascript), move on. Stop pasting sensitive information into sketchy sites to format JSON, compute a hash, etc.</p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -53,7 +53,7 @@
       <description>
         <ul>
           <li>Search now looks at the description and tags on scripts</li>
-          <li>Errors and infomation are now notifications removing the need for the status bar</li>
+          <li>Errors and information are now notifications removing the need for the status bar</li>
           <li>Added version number to the about dialog</li>
         </ul>
       </description>
@@ -110,7 +110,7 @@
     <release version="0.2.1" date="2020-07-28">
       <description>
         <ul>
-          <li>Fix JWT decoder script (for more infomation, see the release notes of Boop 1.2.1).</li>
+          <li>Fix JWT decoder script (for more information, see the release notes of Boop 1.2.1).</li>
           <li>Remove unsafe Rust sections</li>
         </ul>
       </description>
@@ -118,7 +118,7 @@
     <release version="0.2.0" date="2020-07-20">
       <description>
         <ul>
-          <li>Compatability with Boop 1.2.0 scripts (`state.insert(..)` and `require(..)`).</li>
+          <li>Compatibility with Boop 1.2.0 scripts (`state.insert(..)` and `require(..)`).</li>
           <li>Custom icons for scripts from Boop.</li>
         </ul>
       </description>
@@ -128,7 +128,7 @@
         <ul>
           <li>Windows build available</li>
           <li>Application menu with links to config directory and website to get more scripts.</li>
-          <li>Scripts now retain the enviroment they where executed in to match Boop</li>
+          <li>Scripts now retain the environment they where executed in to match Boop</li>
         </ul>
       </description>
     </release>

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl Config {
 
         let config = settings
             .try_into()
-            .wrap_err("Failed to covert settings into Config")?;
+            .wrap_err("Failed to convert settings into Config")?;
 
         Ok((config, config_file_created)) // TODO: handle results
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -226,7 +226,7 @@ impl Executor {
             (v8::Global::new(scope, context), main_function)
         };
 
-        // set status slot, stores execution infomation
+        // set status slot, stores execution information
         let status_slot: Rc<RefCell<ExecutionStatus>> =
             Rc::new(RefCell::new(ExecutionStatus::default()));
         isolate.set_slot(status_slot);
@@ -300,7 +300,7 @@ impl Executor {
             .wrap_err("failed to created require function")?;
         global.set(scope, require_key.into(), require_val.into());
 
-        // complile and run script
+        // compile and run script
         let code = v8::String::new(scope, source).ok_or(ExecutorError::SourceExceedsMaxLength)?;
 
         let tc_scope = &mut v8::TryCatch::new(scope);
@@ -689,7 +689,7 @@ impl Executor {
 
         rv.set(
             v8::String::new(scope, &text)
-                .expect("faield to create JS string from text")
+                .expect("failed to create JS string from text")
                 .into(),
         );
     }
@@ -709,7 +709,7 @@ impl Executor {
 
         let slot = scope
             .get_slot_mut::<Rc<RefCell<ExecutionStatus>>>()
-            .expect("faield to get mutable access status slot");
+            .expect("failed to get mutable access status slot");
 
         let mut slot = slot.borrow_mut();
 
@@ -861,7 +861,7 @@ mod tests {
     fn test_error_require_internal_script() {
         init();
         let source = r#"function main() {
-            let foo = require("@boop/non-existant");
+            let foo = require("@boop/non-existent");
         }"#;
 
         assert_eq!(
@@ -872,11 +872,11 @@ mod tests {
                 .downcast::<ExecutorError>()
                 .unwrap(),
             ExecutorError::Execute(JSException {
-                exception_str: "Error: No internal script with path \"@boop/non-existant.js\""
+                exception_str: "Error: No internal script with path \"@boop/non-existent.js\""
                     .to_string(),
                 resource_name: Some("undefined".to_string()),
                 source_line: Some(
-                    "            let foo = require(\"@boop/non-existant\");".to_string()
+                    "            let foo = require(\"@boop/non-existent\");".to_string()
                 ),
                 line_number: Some(2),
                 columns: Some((22, 23))

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ lazy_static! {
     static ref XDG_DIRS: xdg::BaseDirectories = match xdg::BaseDirectories::with_prefix("boop-gtk")
     {
         Ok(dirs) => dirs,
-        Err(err) => panic!("Unable to find XDG directorys: {}", err),
+        Err(err) => panic!("Unable to find XDG directories: {}", err),
     };
 }
 
@@ -113,8 +113,8 @@ fn main() -> Result<()> {
 
         Window::set_default_icon_name("fyi.zoey.Boop-GTK");
 
-        // must be fetched _before_ widgets are proccessed since the language managers search path must
-        // be set immediantly after creation:
+        // must be fetched _before_ widgets are processed since the language managers search path must
+        // be set immediately after creation:
         // https://developer.gnome.org/gtksourceview/stable/GtkSourceLanguageManager.html#gtk-source-language-manager-set-search-path
         let boop_language = || -> Result<Language> {
             let language_manager = sourceview::LanguageManager::get_default()
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
             dirs.push(&config_dir_path);
             language_manager.set_search_path(&dirs);
 
-            info!("language manager search directorys: {}", dirs.join(":"));
+            info!("language manager search directories: {}", dirs.join(":"));
 
             language_manager
                 .get_language("boop")

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -114,9 +114,9 @@ impl App {
         {
             let preference_dialog = app.preferences_dialog.clone();
             app.preferences_button.connect_clicked(move |_| {
-                let responce = preference_dialog.run();
-                if responce == gtk::ResponseType::DeleteEvent
-                    || responce == gtk::ResponseType::Cancel
+                let response = preference_dialog.run();
+                if response == gtk::ResponseType::DeleteEvent
+                    || response == gtk::ResponseType::Cancel
                 {
                     preference_dialog.hide();
                 }
@@ -166,9 +166,9 @@ impl App {
         {
             let about_dialog: AboutDialog = app.about_dialog.clone();
             app.about_button.connect_clicked(move |_| {
-                let responce = about_dialog.run();
-                if responce == gtk::ResponseType::DeleteEvent
-                    || responce == gtk::ResponseType::Cancel
+                let response = about_dialog.run();
+                if response == gtk::ResponseType::DeleteEvent
+                    || response == gtk::ResponseType::Cancel
                 {
                     about_dialog.hide();
                 }

--- a/src/ui/shortcuts_window.rs
+++ b/src/ui/shortcuts_window.rs
@@ -7,7 +7,7 @@ pub struct ShortcutsWindow {
 }
 
 const GENERAL_SHORTCUTS: [(&str, &str); 3] = [
-    ("Open Command Pallette", "<Primary><Shift>P"),
+    ("Open Command Palette", "<Primary><Shift>P"),
     ("Quit", "<Primary>Q"),
     ("Re-execute Last Script", "<Primary><Shift>B"),
 ];


### PR DESCRIPTION
Found via `codespell -S target -L crate,fo,okat`